### PR TITLE
Replace star imports with explicit imports

### DIFF
--- a/QA_expts/plot_medical_QA_results.ipynb
+++ b/QA_expts/plot_medical_QA_results.ipynb
@@ -14,17 +14,7 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import os\n",
-    "import json\n",
-    "import pickle\n",
-    "from utils import *\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib.transforms as mtransforms"
-   ]
+   "source": "import numpy as np\nimport pandas as pd\nimport os\nimport json\nimport pickle\nfrom utils import remove_specific_leading_chars\n\nimport matplotlib.pyplot as plt\nimport matplotlib.transforms as mtransforms"
   },
   {
    "cell_type": "code",

--- a/QA_expts/run_gcrc_expts.py
+++ b/QA_expts/run_gcrc_expts.py
@@ -21,7 +21,13 @@ import argparse
 
 from typing import List
 
-from utils import *
+from utils import (
+    get_frac_true_claims_retained,
+    get_taus_grid_from_data,
+    hb_p_value,
+    remove_specific_leading_chars,
+    split_dataset,
+)
 
 
 """Loss function for subclaim factuality False Discovery Rate (FDR)"""

--- a/cpc_llm/src/cpc_llm/core/compute_liks_all_models_one_target.py
+++ b/cpc_llm/src/cpc_llm/core/compute_liks_all_models_one_target.py
@@ -12,8 +12,7 @@ import torch
 
 from ..test_functions.finetune_utils import formatting_texts_func_single_seq
 
-# from ..core.model_client import ModelClient
-from ..core.model_client import *
+from ..core.model_client import ModelClient
 from omegaconf import DictConfig, OmegaConf
 
 

--- a/cpc_llm/src/cpc_llm/main.py
+++ b/cpc_llm/src/cpc_llm/main.py
@@ -17,9 +17,22 @@ from .infer.rejection_sampling import (
     run_iterative_generation,
     accept_reject_sample_and_get_likelihoods,
 )
-from .infrastructure.orchestration import *
-from .data.combine_and_split import *
-from .data.select import *
+from .infrastructure.orchestration import (
+    create_propen_preference_dataset,
+    create_propen_sft_dataset,
+    generate_ga_dataset,
+    run_compute_liks_all_models_and_cal_data,
+    train_dpo,
+    train_gpt,
+    train_initial_sft,
+    train_marge,
+    train_sft,
+)
+from .data.combine_and_split import (
+    combine_new_with_old_datasets,
+    train_cal_split_gen_outputs,
+)
+from .data.select import get_seeds_from_training_data
 from .infer.generation_utils import get_temperatures
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,6 @@ dependencies = []
 [tool.uv.workspace]
 members = ["cpc_llm"]
 
-[tool.ruff.lint]
-ignore = [
-    "F403",  # star imports — deeply embedded, defer to a dedicated refactor
-    "F405",  # names possibly undefined from star imports (consequence of F403)
-]
-
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = [
     "E402",  # import order in notebooks is often intentional
@@ -24,5 +18,6 @@ ignore = [
 "constrained_AL/run_SplitCP_MFCS_ALexpts.py" = ["E402"]  # sys.path manipulation before imports
 "constrained_AL/calibrate_mfcs.py" = ["F821"]  # references to names in dead code path
 "cpc_llm/src/cpc_llm/calibrate/cpc_search.py" = ["F821"]  # likely typo (betas_t), needs investigation
+"cpc_llm/src/cpc_llm/main.py" = ["F821"]  # likely typo (cal_liks_df_tmin1 vs t0), needs investigation
 "cpc_llm/src/cpc_llm/infer/rejection_sampling.py" = ["F821"]  # undefined target_lik/prop_lik, needs investigation
 "cpc_llm/src/cpc_llm/test_functions/finetune_ehrlich.py" = ["E402"]  # conditional import after try/except


### PR DESCRIPTION
## Summary
- Convert all 6 `from x import *` statements to explicit named imports
- Remove global F403/F405 suppression from `pyproject.toml` (no longer needed)
- Surfaced a pre-existing bug: `cal_liks_df_tmin1_safe_and_t_unconstrained_mat` in `main.py:1061` is likely a typo for `cal_liks_df_t0_safe_and_t_unconstrained_mat` (defined on line 1052). Added F821 suppression for now.

## Changes
| File | Old | New |
|------|-----|-----|
| `cpc_llm/main.py` | 3 star imports from orchestration, combine_and_split, select | 12 explicit names |
| `cpc_llm/core/compute_liks_all_models_one_target.py` | `from ..core.model_client import *` | `from ..core.model_client import ModelClient` |
| `QA_expts/run_gcrc_expts.py` | `from utils import *` | 5 explicit names |
| `QA_expts/plot_medical_QA_results.ipynb` | `from utils import *` | `from utils import remove_specific_leading_chars` |

## Test plan
- [x] `ruff check .` passes (all F403/F405 resolved)
- [x] `ruff format --check .` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)