### PR TITLE
Add Claude Code review GitHub Action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds automatic PR code review via `anthropics/claude-code-action@v1`
- Runs `/review` on PR open/synchronize
- Responds to `@claude` mentions in PR and issue comments

## Test plan
- [x] `ANTHROPIC_API_KEY` secret added to repository
- [ ] Verify review comment appears on this PR once CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)