### PR TITLE
Eliminate redundant target tokenization in compute_likelihoods

### DIFF
--- a/cpc_llm/src/cpc_llm/core/model_client.py
+++ b/cpc_llm/src/cpc_llm/core/model_client.py
@@ -822,8 +822,9 @@ class ModelClient:
 
             next_token_probs = next_token_probs.cpu().numpy()
 
-            targets_tokenized = self._tokenize_batch(targets[start_index:end_index])
-            targets_seq_lens = targets_tokenized.attention_mask.sum(-1).cpu().numpy()
+            targets_seq_lens = (
+                (tokenized.attention_mask.sum(-1) - input_seq_lens).cpu().numpy()
+            )
             avg_likelihoods = list(next_token_probs.sum(-1) / targets_seq_lens)
             # logger.info(f"avg_likelihoods shape : {np.shape(avg_likelihoods)}")
             # logger.info(f"seq likelihood : {list(next_token_probs.prod(-1) / targets_seq_lens)}")


### PR DESCRIPTION
## Summary
- Removes the third (target-only) `_tokenize_batch` call in `compute_likelihoods()`
- Derives `targets_seq_lens` by subtracting `input_seq_lens` from the combined sequence lengths, which are already computed
- No new assumptions — the code already relies on tokenization being additive across the input/target boundary

Closes #23

## Test plan
- [x] All 50 existing tests pass (`uv run pytest tests/ -v`)
- [ ] GPU test in `model_client_test.py` validates likelihoods match `model.generate` + `compute_transition_scores` to 5 decimal places

🤖 Generated with [Claude Code](https://claude.com/claude-code)