### PR TITLE
Phase 1: Migrate SFT trainer call sites to modern trl API

### DIFF
--- a/cpc_llm/src/cpc_llm/test_functions/finetune_ehrlich.py
+++ b/cpc_llm/src/cpc_llm/test_functions/finetune_ehrlich.py
@@ -264,7 +264,7 @@ def main(cfg: DictConfig):
             args=training_args,
             train_dataset=train_dataset,
             eval_dataset=eval_dataset,
-            tokenizer=tokenizer,
+            processing_class=tokenizer,
             peft_config=get_peft_config(model_config),
             callbacks=callbacks,
             formatting_func=formatting_fn,

--- a/cpc_llm/src/cpc_llm/train/seq2seq_sft_trainer.py
+++ b/cpc_llm/src/cpc_llm/train/seq2seq_sft_trainer.py
@@ -83,33 +83,6 @@ class Seq2SeqSFTConfig(SFTConfig):
         return d
 
 
-# class S3Callback(TrainerCallback):
-#     def __init__(self, s3_output_dir: str, logger: logging.Logger = None):
-#         self.s3_output_dir = s3_output_dir
-#         if not self.s3_output_dir.endswith("/"):
-#             self.s3_output_dir += "/"
-#         self.logger = logger
-#         self.s3 = s3fs.S3FileSystem()
-
-#     def on_save(
-#         self,
-#         args: TrainingArguments,
-#         state: TrainerState,
-#         control: TrainerControl,
-#         **kwargs,
-#     ):
-#         """
-#         Copy all local checkpoint files to S3!
-#         """
-#         checkpoint_folder_name = f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}"
-#         checkpoint_dir = os.path.join(args.output_dir, checkpoint_folder_name)
-#         self.s3.put(checkpoint_dir, self.s3_output_dir, recursive=True)
-#         if self.logger is not None:
-#             self.logger.info(
-#                 f"Successfully copied checkpoint in {checkpoint_dir} to {self.s3_output_dir}."
-#             )
-
-
 class S3Callback(TrainerCallback):
     def __init__(self, s3_output_dir: str, logger: logging.Logger = None):
         self.s3_output_dir = s3_output_dir


### PR DESCRIPTION
## Summary

Phase 1 of #37 (tracking issue for #19).

- Update `finetune_ehrlich.py` to pass `processing_class=` instead of `tokenizer=` when constructing `Seq2SeqSFTTrainer`
- Remove commented-out dead code from `seq2seq_sft_trainer.py`

The trainer itself was already migrated in a prior PR — this cleans up the remaining call site.

## Test plan

- [x] `uv run pytest tests/ -v` — 59 tests pass
- [ ] `uv run modal run modal_runner.py --smoke` — smoke test (exercises SFT training)

🤖 Generated with [Claude Code](https://claude.com/claude-code)