### PR TITLE
Remove breakpoint() calls from production code

### DIFF
--- a/cpc_llm/src/cpc_llm/calibrate/cpc_search.py
+++ b/cpc_llm/src/cpc_llm/calibrate/cpc_search.py
@@ -84,7 +84,6 @@ def cpc_beta_search(
         )
 
         ## Subset to currently relevant likelihood columns (relevant for rerunning from checkpoint)
-        # breakpoint()
 
         # cal_data_constrained_curr = cal_data_constrained_curr[list(cal_data_constrained_curr.columns[0:2]) + constrained_lik_cols]
         # cal_data_unconstrained_curr = cal_data_unconstrained_curr[list(cal_data_unconstrained_curr.columns[0:2]) + unconstrained_lik_cols]
@@ -141,7 +140,6 @@ def cpc_beta_search(
                 )
 
             else:
-                breakpoint()
                 logger.info(
                     f"cal_data_constrained_all.columns : {cal_data_constrained_all.columns}"
                 )

--- a/cpc_llm/src/cpc_llm/core/compute_likelihoods_one_model_all_data.py
+++ b/cpc_llm/src/cpc_llm/core/compute_likelihoods_one_model_all_data.py
@@ -113,7 +113,6 @@ def compute_likelihoods_one_model_all_data(
     input_df = pd.read_json(input_fp, orient="records", lines=True)
     # input_ds = datasets.Dataset.from_pandas(input_df)
     input_data = input_df.to_dict("list")
-    # breakpoint()
     formatted_inputs = formatting_texts_func_single_seq(input_data)
 
     # last_timestep_idx = len(cfg.prev_target_data_path_list) - 1
@@ -134,7 +133,6 @@ def compute_likelihoods_one_model_all_data(
             target_df = target_df[target_df.columns[0:2] + lik_col_names_prev]
 
         target_data = target_df.to_dict("list")
-        # breakpoint()
         formatted_targets = formatting_texts_func_single_seq(target_data)
 
         ## Compute likelihoods

--- a/cpc_llm/src/cpc_llm/core/score.py
+++ b/cpc_llm/src/cpc_llm/core/score.py
@@ -20,7 +20,6 @@ def score(cfg: DictConfig, logger: logging.Logger = None):
         max_generate_length=1,  # don't need to generate, only scoring
         device="cuda" if torch.cuda.is_available() else "cpu",
     )
-    # breakpoint()
     df = pd.read_json(cfg.data_path, orient="records", lines=True)
     if cfg.sanity_check:
         logger.warning(
@@ -49,7 +48,6 @@ def score(cfg: DictConfig, logger: logging.Logger = None):
     ['[12, 31, 2, 15, 15, 6, 14, 9, 12, 31, 11, 10, 25, 1, 15, 11, 19, 24, 10, 5, 19, 27, 1, 14, 31, 28, 16, 15, 11, 14, 16, 15]', 
      '[12, 31, 2, 4, 15, 6, 14, 9, 12, 31, 11, 10, 25, 1, 14, 11, 19, 24, 10, 5, 17, 27, 1, 14, 31, 28, 15, 15, 14, 14, 16, 15]']
     """
-    # breakpoint()
     formatted_targets = [json.dumps(target) for target in data[cfg.target_field]]
     # avg_likelihoods = model_client.compute_likelihoods(
     avg_likelihoods = model_client.compute_likelihoods_avg(

--- a/cpc_llm/src/cpc_llm/core/score2.py
+++ b/cpc_llm/src/cpc_llm/core/score2.py
@@ -19,7 +19,6 @@ def score(cfg: DictConfig, logger: logging.Logger = None):
         max_generate_length=500,
         device="cuda" if torch.cuda.is_available() else "cpu",
     )
-    # breakpoint()
     input_df = pd.read_json(cfg.input_data_path, orient="records", lines=True)
     target_df = pd.read_json(cfg.target_data_path, orient="records", lines=True)
     if cfg.sanity_check:
@@ -46,11 +45,9 @@ def score(cfg: DictConfig, logger: logging.Logger = None):
     ['[12, 31, 2, 15, 15, 6, 14, 9, 12, 31, 11, 10, 25, 1, 15, 11, 19, 24, 10, 5, 19, 27, 1, 14, 31, 28, 16, 15, 11, 14, 16, 15]', 
      '[12, 31, 2, 4, 15, 6, 14, 9, 12, 31, 11, 10, 25, 1, 14, 11, 19, 24, 10, 5, 17, 27, 1, 14, 31, 28, 15, 15, 14, 14, 16, 15]']
     """
-    # breakpoint()
     formatted_targets = formatting_texts_func_single_seq(target_data)
     # formatted_targets = [json.dumps(target) for target in data[cfg.target_field]]
     # avg_likelihoods = model_client.compute_likelihoods(
-    # breakpoint()
     avg_likelihoods = model_client.compute_likelihoods_avg(
         formatted_inputs,
         formatted_targets,

--- a/cpc_llm/src/cpc_llm/main.py
+++ b/cpc_llm/src/cpc_llm/main.py
@@ -701,8 +701,6 @@ def run_pipeline(cfg: DictConfig):
                 )
 
             if constrained_liks_df_beta_hat.iloc[0, 0] != unconstrained_df.iloc[0, 0]:
-                breakpoint()
-                ## Sanity check
                 raise ValueError(
                     f"constrained_liks_df_beta_hat.iloc[0,0] ({constrained_liks_df_beta_hat.iloc[0, 0]}) != ({unconstrained_df.iloc[0, 0]}) unconstrained_df.iloc[0,0]"
                 )


### PR DESCRIPTION
## Summary
- Removes 2 active `breakpoint()` calls in `cpc_search.py` and `main.py` that would hang production runs
- Removes 8 commented-out `breakpoint()` calls across `score.py`, `score2.py`, and `compute_likelihoods_one_model_all_data.py`

Closes #42

## Test plan
- [x] `grep -r 'breakpoint()' cpc_llm/` returns no matches
- [x] All 59 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)