### PR TITLE
Replace broad except clauses with specific exception types

### DIFF
--- a/cpc_llm/src/cpc_llm/infrastructure/slurm_utils.py
+++ b/cpc_llm/src/cpc_llm/infrastructure/slurm_utils.py
@@ -241,7 +241,7 @@ def _log_direct_failure(rc: int, log_path: str, cmd: str = ""):
             lines = f.readlines()
             tail = "".join(lines[-30:])
             logging.error(f"Command failed (rc={rc}). Output tail:\n{tail}")
-    except Exception:
+    except OSError:
         logging.error(f"Command failed (rc={rc}). See {log_path}")
 
 

--- a/cpc_llm/src/cpc_llm/test_functions/finetune_ehrlich.py
+++ b/cpc_llm/src/cpc_llm/test_functions/finetune_ehrlich.py
@@ -194,7 +194,7 @@ def main(cfg: DictConfig):
         transformers_logger = transformers_logging.get_logger("transformers")
         try:
             transformers_logger.setLevel(cfg.log_level.upper())
-        except Exception:
+        except (ValueError, AttributeError):
             logger.warning(
                 f"Could not set transformers logger to level {cfg.log_level}. Keeping defaults..."
             )

--- a/cpc_llm/src/cpc_llm/test_functions/finetune_utils.py
+++ b/cpc_llm/src/cpc_llm/test_functions/finetune_utils.py
@@ -558,7 +558,7 @@ class EvaluatorPlainPairs:
                     if int(x) != x:
                         continue
                     particle.append(int(x))
-            except Exception:
+            except (json.JSONDecodeError, ValueError, TypeError, AssertionError):
                 # not parsable
                 maybe_log(
                     self.logger,
@@ -814,7 +814,7 @@ class EvaluatorEditPairs:
                     if int(x) != x:
                         continue
                     particle.append(int(x))
-            except Exception:
+            except (json.JSONDecodeError, ValueError, TypeError, AssertionError):
                 # not parsable
                 maybe_log(
                     self.logger,
@@ -962,7 +962,7 @@ def get_ehrlich_metrics_for_outputs(
             assert isinstance(o_list, list)
             assert all([int(x) == x for x in o_list])
             particle = [int(x) for x in o_list]
-        except Exception:
+        except (json.JSONDecodeError, ValueError, TypeError, AssertionError):
             logging.warning(f"Prediction is not parsable. Continuing. Prediction:\n{o}")
             all_scores_including_nulls.append(None)
             continue

--- a/cpc_llm/src/cpc_llm/train/dpo.py
+++ b/cpc_llm/src/cpc_llm/train/dpo.py
@@ -145,7 +145,7 @@ def main(cfg: DictConfig):
             transformers_logging, f"set_verbosity_{cfg.log_level}"
         )
         set_verbosity_fn()
-    except Exception:
+    except (AttributeError, ValueError):
         logging.warning(
             f"Could not set transformers logger to level {cfg.log_level}. Keeping defaults..."
         )

--- a/cpc_llm/src/cpc_llm/train/marge.py
+++ b/cpc_llm/src/cpc_llm/train/marge.py
@@ -99,7 +99,7 @@ def main(cfg: DictConfig):
     transformers_logger = transformers_logging.get_logger("transformers")
     try:
         transformers_logger.setLevel(cfg.log_level.upper())
-    except Exception:
+    except (ValueError, AttributeError):
         transformers_logger.warning(
             f"Could not set transformers logger to level {cfg.log_level}. Keeping defaults..."
         )

--- a/cpc_llm/src/cpc_llm/train/pref_tuning_trainer.py
+++ b/cpc_llm/src/cpc_llm/train/pref_tuning_trainer.py
@@ -96,7 +96,7 @@ class DPOTrainerWithLogging(DPOTrainer):
                 assert isinstance(o_list, list)
                 assert all([int(x) == x for x in o_list])
                 particle = [int(x) for x in o_list]
-            except Exception:
+            except (json.JSONDecodeError, ValueError, TypeError, AssertionError):
                 logger.warning(
                     f"Prediction is not parsable. Continuing. Prediction:\n{o}"
                 )


### PR DESCRIPTION
## Summary
- Replaces 8 `except Exception:` clauses across 6 files with specific exception types
- JSON parsing blocks (`finetune_utils.py`, `pref_tuning_trainer.py`): `except (json.JSONDecodeError, ValueError, TypeError, AssertionError)`
- Log level configuration (`finetune_ehrlich.py`, `dpo.py`, `marge.py`): `except (ValueError, AttributeError)` / `except (AttributeError, ValueError)`
- File I/O fallback (`slurm_utils.py`): `except OSError`

Closes #43

## Test plan
- [x] `grep -r 'except Exception:' cpc_llm/` returns no matches
- [x] All 59 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)