### PR TITLE
Add tqdm to find_preference_pairs output loop

### DIFF
--- a/cpc_llm/src/cpc_llm/data/synthetic_dataset_formatter.py
+++ b/cpc_llm/src/cpc_llm/data/synthetic_dataset_formatter.py
@@ -430,7 +430,9 @@ def find_preference_pairs(cfg: DictConfig, df: pd.DataFrame) -> List[Dict[str, A
                 idx_triples.add((i, pair_idx[1], pair_idx[0]))
     idx_triples = list(idx_triples)
     outputs = []
-    for x_idx, yw_idx, yl_idx in idx_triples:
+    for x_idx, yw_idx, yl_idx in tqdm(
+        idx_triples, desc="Creating preference output records"
+    ):
         output_dict = {
             "prompt": filtered[x_idx].tolist(),
             "prompt_score": f"{filtered_scores[x_idx]:.3f}",


### PR DESCRIPTION
## Problem

The `find_preference_pairs` function's output record creation loop (~983K iterations) had no progress output. This caused Modal's 900s runner heartbeat timeout to kill the container mid-execution, since Modal uses stdout/stderr activity to confirm the runner is alive.

## Fix

Add `tqdm` to the output loop in `find_preference_pairs`, matching the existing pattern in `find_dense_pairs`.

## Test plan

- [x] `uv run pytest tests/ -v` — 89 passed
- [ ] Full pipeline run with DPO (exercises `find_preference_pairs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)