### PR TITLE
Revert generation batch sizes to original values

### DIFF
--- a/cpc_llm/config/cpc_llm.yaml
+++ b/cpc_llm/config/cpc_llm.yaml
@@ -58,8 +58,8 @@ seed: 0
 greedy_decoding: False ## For initial and iterative
 temperature_scaling: False #True
 job_submission_system: slurm
-greedy_gen_batch_size: 256
-sampling_gen_batch_size: 256
+greedy_gen_batch_size: 64
+sampling_gen_batch_size: 32
 initial_model: "EleutherAI/pythia-14m" # "EleutherAI/pythia-2.8b"
 sanity_check: False  # will be propagated to all training + generation jobs
 path_to_repo: null # /scratch/ac5968/llome


### PR DESCRIPTION
## Summary

Fixes #81.

- Revert `sampling_gen_batch_size: 256 → 32`
- Revert `greedy_gen_batch_size: 256 → 64`

When `subsample_seeds=True` (the default), the batch size controls how many seeds are drawn per inner iteration in `generate_texts_batched`, changing the total number of generated sequences. The increase to 256 in #67 roughly doubled generation output, affecting downstream training data volume.

## Test plan

- [x] Config-only change, no code modified
- [ ] Smoke test on Modal to verify pipeline still completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)