### PR TITLE
Add sweep analysis scripts

### DIFF
--- a/analysis/extract_sweep_data.py
+++ b/analysis/extract_sweep_data.py
@@ -57,13 +57,24 @@ def extract_sweep_data(
     alpha_set = set(alphas) if alphas else None
     seed_set = set(seeds) if seeds else None
 
-    def score_stats(df: pd.DataFrame) -> dict:
+    def score_stats(df: pd.DataFrame) -> dict[str, float | int | None]:
+        """Compute feasibility and score statistics from a scored DataFrame.
+
+        Args:
+            df: DataFrame with a ``score`` column. Infeasible samples have
+                non-finite scores (NaN or ±inf).
+
+        Returns:
+            Dict with ``frac_infeasible``, ``mean_score``, ``max_score``,
+            ``n_total``, and ``n_feasible``.
+        """
         scores = df["score"].to_numpy(dtype=float)
         finite = scores[np.isfinite(scores)]
         return {
             "frac_infeasible": 1.0 - len(finite) / len(scores)
             if len(scores) > 0
             else None,
+            # Raw scores are negative (closer to 0 is better); negate for display
             "mean_score": float(-np.mean(finite)) if len(finite) else None,
             "max_score": float(-np.min(finite)) if len(finite) else None,
             "n_total": len(scores),
@@ -125,7 +136,9 @@ def extract_sweep_data(
             if not accepted_files:
                 continue
             try:
-                df = pd.read_json(accepted_files[0], orient="records", lines=True)
+                df = pd.read_json(
+                    sorted(accepted_files)[0], orient="records", lines=True
+                )
                 if "score" not in df.columns:
                     continue
                 row = {"seed": seed, "alpha": alpha, "round_idx": round_idx}
@@ -138,7 +151,7 @@ def extract_sweep_data(
 
 
 @app.local_entrypoint()
-def main():
+def main() -> None:
     results = extract_sweep_data.remote()
     out_path = Path("sweep_data.json")
     out_path.write_text(json.dumps(results, indent=2))

--- a/analysis/plot_sweep.py
+++ b/analysis/plot_sweep.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import argparse
 import json
 import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -72,14 +74,25 @@ def build_lookup(
         if r0:
             for a in alphas:
                 if (a, s, 0) not in lookup:
-                    lookup[(a, s, 0)] = r0
+                    lookup[(a, s, 0)] = dict(r0)
     return lookup
 
 
 def get_series(
     lookup: dict, alpha: float, seeds: list[int], max_round: int, metric: str
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Per-seed values for a metric across rounds."""
+    """Gather per-seed values for a metric across rounds.
+
+    Args:
+        lookup: (alpha, seed, round_idx) -> row dict.
+        alpha: Alpha value to query.
+        seeds: Seed values to include.
+        max_round: Maximum round index.
+        metric: Key to extract from each row.
+
+    Returns:
+        Tuple of (rounds array, per-seed values array of shape (n_seeds, n_rounds)).
+    """
     rounds = np.arange(0, max_round + 1)
     per_seed = []
     for s in seeds:
@@ -90,7 +103,17 @@ def get_series(
 def get_cummax_series(
     lookup: dict, alpha: float, seeds: list[int], max_round: int
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Per-seed cumulative max of max_score across rounds."""
+    """Compute per-seed cumulative max of max_score across rounds.
+
+    Args:
+        lookup: (alpha, seed, round_idx) -> row dict.
+        alpha: Alpha value to query.
+        seeds: Seed values to include.
+        max_round: Maximum round index.
+
+    Returns:
+        Tuple of (rounds array, per-seed cummax array of shape (n_seeds, n_rounds)).
+    """
     rounds = np.arange(0, max_round + 1)
     per_seed = []
     for s in seeds:
@@ -112,7 +135,6 @@ def plot_sweep(data: list[dict], output: str = "sweep_results.png") -> None:
         data: List of per-round metric dicts from extract_sweep_data.
         output: Path to save the figure.
     """
-    matplotlib.use("Agg")
     sns.set_theme(style="white", font_scale=1.1)
 
     alphas = sorted({r["alpha"] for r in data})


### PR DESCRIPTION
## Summary

- `analysis/extract_sweep_data.py` — Modal script to extract per-round accepted sample metrics (fraction infeasible, mean score, max score) from sweep outputs on the Modal volume
- `analysis/plot_sweep.py` — Generate 3-panel figure (risk, avg score, cumulative max score) comparing CPC-constrained policies at different alpha levels against the uncontrolled baseline

## Usage

```bash
# Extract data from Modal volume
modal run analysis/extract_sweep_data.py

# Generate plots (local, no Modal needed)
python analysis/plot_sweep.py sweep_data.json -o sweep_results.png
```

## Test plan

- [x] Extraction script tested against replication sweep outputs (16 jobs, 4 seeds × 4 alphas)
- [x] Plot script verified — reproduces 3-panel figure matching reference paper layout
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)