### PR TITLE
Revert eval/save to step-based and fix inf parsing crash

### DIFF
--- a/cpc_llm/config/cpc_llm.yaml
+++ b/cpc_llm/config/cpc_llm.yaml
@@ -217,8 +217,8 @@ initial_sft:
     training_args:
       num_train_epochs: 10 #10 #2 #10
       seed: 0
-      eval_strategy: epoch
-      save_strategy: epoch
+      eval_steps: 0.1
+      save_steps: 0.2
       learning_rate: 1e-6
       per_device_train_batch_size: 32 #16 #2
       per_device_eval_batch_size: 256
@@ -271,8 +271,8 @@ sft:
     training_args:
       num_train_epochs: 2  #5
       seed: 0
-      eval_strategy: epoch
-      save_strategy: epoch
+      eval_steps: 0.1
+      save_steps: 0.2
       learning_rate: 1e-4 #1e-6
       per_device_train_batch_size: 16 #2
       per_device_eval_batch_size: 256
@@ -472,8 +472,8 @@ dpo:
       beta: 0.4
       gradient_accumulation_steps: 1
       num_train_epochs: 1 #1 #2 #2 #1
-      eval_strategy: epoch
-      save_strategy: epoch
+      eval_steps: 0.1
+      save_steps: 0.2
       torch_compile: false
       max_length: 256
       log_level: "info"
@@ -508,8 +508,8 @@ marge:
       beta: 10.0
       gradient_accumulation_steps: 1
       num_train_epochs: 1
-      eval_strategy: epoch
-      save_strategy: epoch
+      eval_steps: 0.1
+      save_steps: 0.2
       torch_compile: false
       self_normalize_weights: True
       reinforce_style: False

--- a/cpc_llm/config/cpc_llm.yaml
+++ b/cpc_llm/config/cpc_llm.yaml
@@ -217,7 +217,9 @@ initial_sft:
     training_args:
       num_train_epochs: 10 #10 #2 #10
       seed: 0
+      eval_strategy: steps
       eval_steps: 0.1
+      save_strategy: steps
       save_steps: 0.2
       learning_rate: 1e-6
       per_device_train_batch_size: 32 #16 #2
@@ -271,7 +273,9 @@ sft:
     training_args:
       num_train_epochs: 2  #5
       seed: 0
+      eval_strategy: steps
       eval_steps: 0.1
+      save_strategy: steps
       save_steps: 0.2
       learning_rate: 1e-4 #1e-6
       per_device_train_batch_size: 16 #2
@@ -472,7 +476,9 @@ dpo:
       beta: 0.4
       gradient_accumulation_steps: 1
       num_train_epochs: 1 #1 #2 #2 #1
+      eval_strategy: steps
       eval_steps: 0.1
+      save_strategy: steps
       save_steps: 0.2
       torch_compile: false
       max_length: 256
@@ -508,7 +514,9 @@ marge:
       beta: 10.0
       gradient_accumulation_steps: 1
       num_train_epochs: 1
+      eval_strategy: steps
       eval_steps: 0.1
+      save_strategy: steps
       save_steps: 0.2
       torch_compile: false
       self_normalize_weights: True

--- a/cpc_llm/src/cpc_llm/test_functions/finetune_utils.py
+++ b/cpc_llm/src/cpc_llm/test_functions/finetune_utils.py
@@ -397,7 +397,7 @@ def parse_particle_and_score_permissive(
     try:
         if any([int(x) != x for x in particle]):
             return None
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, OverflowError):
         return None
     particle = [
         int(x) for x in particle

--- a/sweep_configs/unconstrained_8seeds.yaml
+++ b/sweep_configs/unconstrained_8seeds.yaml
@@ -1,0 +1,14 @@
+# Unconstrained baseline: 8 seeds x alpha=1.0 = 8 parallel jobs.
+# Full DPO pipeline (10 rounds) on pythia-14m, each on its own A100.
+#
+# Usage:
+#   modal deploy modal_runner.py
+#   modal run modal_runner.py --sweep sweep_configs/unconstrained_8seeds.yaml
+
+base_config: cpc_llm
+cache: false
+overrides: []
+
+parameters:
+  initial_seed: [0, 1, 2, 3, 4, 5, 6, 7]
+  conformal_policy_control.alpha: [1.0]


### PR DESCRIPTION
## Summary

- Revert eval/save strategy from `epoch` back to `eval_steps=0.1` / `save_steps=0.2` across all training configs (initial_sft, sft, dpo, marge) to enable best-checkpoint selection via eval_loss
- Fix `OverflowError: cannot convert float infinity to integer` in `parse_particle_and_score_permissive` — the model can generate `inf` values in particle lists, and the except clause was missing `OverflowError`
- Add sweep config for unconstrained baseline (8 seeds, alpha=1.0)

## Test plan

- [x] 134 tests pass
- [x] Ruff clean
- [ ] Unconstrained sweep running (7/8 seeds pending, 1 hit the inf crash before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)